### PR TITLE
hover transition is fast, footer at bottom for career and jobs pages

### DIFF
--- a/src/astro/src/components/Footer.jsx
+++ b/src/astro/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import '../styles/styles.css';
 
 const Footer = () => { 
     return (
-        <footer className="fixed inset-x-0 bottom-0 text-center">
+        <footer className="absolute inset-x-0 bottom-0 text-center">
             <p className="text-xs text-white">Copyright © 2022 Granola Systems. All rights reserved.</p>
         </footer>
     )

--- a/src/astro/src/components/Nav.jsx
+++ b/src/astro/src/components/Nav.jsx
@@ -6,7 +6,7 @@ const Nav = () => {
         <div className="border-b-[0.03rem] border-solid border-white border-t-0 border-x-0 overflow-auto">
             <nav className="flex items-center gap-6">
                 <a href="/" ><img className="h-[3rem] w-[9rem] sm:h-20 sm:w-60" src="../../images/GranolaHorizontalDarkBg.png" /></a>
-                <a href="/" className="text-xl sm:text-2xl text-white no-underline">Careers</a>
+                <a href="/careers" className="text-xl sm:text-2xl text-white no-underline">Careers</a>
                 <a href="mailto:hello@granola.team" className="text-xl sm:text-2xl text-white no-underline">Contact</a>
             </nav>       
         </div>

--- a/src/astro/src/layouts/CareersLayout.astro
+++ b/src/astro/src/layouts/CareersLayout.astro
@@ -1,7 +1,6 @@
 ---
 import Nav from '../components/Nav'
 import Heading from '../components/Heading.astro'
-import Footer from '../components/Footer'
 import '../styles/styles.css';
 
 const {title} = Astro.props;
@@ -17,14 +16,11 @@ const {title} = Astro.props;
       }
     </style>
   </head>
-<body class="w-full h-full bg-no-repeat bg-cover bg-center bg-fixed bg-logoDark">
-  <Nav />
-  <article class="text-white">
-    <slot />
-  </article>
-</body>
-<footer>
-  <Footer />
-</footer>
+  <body class="w-full h-full bg-no-repeat bg-cover bg-center bg-fixed bg-logoDark">
+    <Nav />
+    <article class="text-white">
+      <slot />
+    </article>
+  </body>
 </html>
 

--- a/src/astro/src/layouts/Layout.astro
+++ b/src/astro/src/layouts/Layout.astro
@@ -15,7 +15,4 @@ const {title} = Astro.props;
     <Nav />
     <Front /> 
 </body>
-<div>
-  <Footer />
-</div>
 </html>

--- a/src/astro/src/pages/careers/[...page].astro
+++ b/src/astro/src/pages/careers/[...page].astro
@@ -19,7 +19,7 @@ const title = "Careers"
         <ul class="h-[50vh] p-0">{page.data.map((jobs: {frontmatter: string; url: string | URL; title: unknown;}) => (
             <li class="flex flex-col flex-shrink p-4 list-none">
                 <a href={jobs.url} class="py-4 px-8 rounded-lg text-logoOrange no-underline text-2xl 
-                bg-white">{jobs.frontmatter.title} &rarr;
+                bg-white hover:bg-slate-400 hover:duration-75">{jobs.frontmatter.title} &rarr;
                 <div class="px-2 pt-2 pb-2">
                     <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">#Remote</span>
                     <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">#Mentorship</span>


### PR DESCRIPTION
The transition rate for hovering over the individual jobs postings is the fastest option in tailwind. The footer at absolute is at the bottom of career and jobs pages. This PR should merge this branch transition into homepage, which wants to merge into main. 